### PR TITLE
Use `CARGO_PKG_VERSION` rather than hard-coded version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "counts"
-version = "1.0.6" # Keep in sync with `VERSION` in main.rs.
+version = "1.0.6"
 authors = ["Nicholas Nethercote <n.nethercote@gmail.com>"]
 license = "Unlicense"
 description = "A command line tool for ad hoc profiling."

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,7 +48,7 @@ OPTIONS:
     -e             Erase weights after applying, replacing them with `NNN`
 ";
 
-const VERSION: &str = "1.0.6";
+const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 fn do_main() -> io::Result<()> {
     // Process args.


### PR DESCRIPTION
Cargo handily makes the version of the crate being compiled available through the [`CARGO_PKG_VERSION` environmental variable](https://doc.rust-lang.org/stable/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-crates)! We can use the [`env!()`](https://doc.rust-lang.org/stable/std/macro.env.html) macro to embed the environmental variable into the constant, avoiding the need to duplicate the version number.

_As an aside, thanks for the cool tool! I rediscovered it today after reading your [post from 2018 on Ad-Hoc Profiling](https://blog.mozilla.org/nnethercote/2018/07/24/ad-hoc-profiling/)._